### PR TITLE
Hotfix Pipeline testing

### DIFF
--- a/.github/workflows/maui-tests.yml
+++ b/.github/workflows/maui-tests.yml
@@ -1,0 +1,51 @@
+name: MAUI Unit Tests
+ 
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - feature/*
+      - release/*
+      - hotfix
+  pull_request:
+    branches:
+      - main
+      - develop
+      - feature/*
+      - release/*
+      - hotfix
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Haal de repository op
+        uses: actions/checkout@v4
+ 
+      - name: Installeer .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+ 
+      - name: Installeer MAUI workloads
+        run: dotnet workload install maui-android
+ 
+      - name: Herstel afhankelijkheden
+        run: dotnet restore
+ 
+      - name: Bouw de applicatie
+        run: dotnet build --configuration Release --no-restore
+ 
+      - name: Voer unit tests uit en genereer rapport + logs
+        run: |
+          mkdir -p TestResults
+          dotnet test --configuration Release --no-restore --no-build --verbosity normal \
+            --logger "trx;LogFileName=test_results.trx" \
+            --results-directory ./TestResults | tee ./TestResults/test_log.txt
+
+      - name: Upload test resultaten + logs als artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: ./TestResults

--- a/Grocery.App/Grocery.App.csproj
+++ b/Grocery.App/Grocery.App.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->


### PR DESCRIPTION
Added pipeline testing for project.
This was overlooked during the initial release

Also removed IOS and MacCatelyst from targeted frameworks for correct building on ubuntu os